### PR TITLE
The simplest CMake setup possible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,11 @@
+project(arcadia)
+cmake_minimum_required(VERSION 2.8)
+
+# no headers
+set(HEADERS )
+
+# there is a single source file
+set(SOURCES arcadia.c)
+
+add_executable(arcadia ${HEADERS} ${SOURCES})
+


### PR DESCRIPTION
Hi, 

I've added a `CMakeLists.txt` file to provide initial support for cmake. **Arcadia** now builds correctly on the Mac OS X 10.9.x. 

Usage:
1. Create a **build** directory and `cd` into it
2. Type `cmake ../` to generate a `Makefile` in linux and mac os x. 

If this is of interest to you, you can accept the pull request. 

Thank you for creating **Arcadia** :)
