### PR TITLE
Added support for GNU readline at the REPL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,27 @@
+# Building with cmake:
+# Create and enter a build directory
+# If compiling with GNU readline run 'cmake .. && make'
+# If compiling without GNU readline run 'cmake -DREAD_LINE=0 .. && make'
+
 project(arcadia)
 cmake_minimum_required(VERSION 2.8)
 
-# no headers
-set(HEADERS )
+# Source files
+set(SOURCES arcadia.c arc.c)
 
-# there is a single source file
-set(SOURCES arcadia.c)
+# If it's not specified, set the READ_LINE macro to the default
+if (NOT DEFINED READ_LINE)
+	set(READ_LINE 1)
+endif()
+ADD_DEFINITIONS(-DREAD_LINE=${READ_LINE})
 
-add_executable(arcadia ${HEADERS} ${SOURCES})
+# The target executable
+add_executable(arcadia ${SOURCES})
 
+# Always link stdmath
+target_link_libraries(arcadia m)
+
+# Only link GNU readline if we're compiling using it
+if (READ_LINE)
+	target_link_libraries(arcadia readline)
+endif()

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,18 @@
 BIN=arcadia
-CFLAGS=-s -Wall -Ofast
+CFLAGS=-Wall -Ofast -c -DREAD_LINE=1
+LDFLAGS=-s -lm -lreadline
+
 $(BIN): arcadia.o arc.o
-	$(CC) $(CFLAGS) -static -o $(BIN) arcadia.o arc.o
+	$(CC) $(LDFLAGS) -o $(BIN) arcadia.o arc.o
+
+no-read-line: LDFLAGS:=$(filter-out -lreadline,$(LDFLAGS))
+no-read-line: CFLAGS+=-UREAD_LINE -DREAD_LINE=0
+no-read-line: $(BIN)
+
 arcadia.o: arcadia.c arc.h
-	$(CC) $(CFLAGS) -c arcadia.c
+	$(CC) $(CFLAGS) arcadia.c
 arc.o: arc.c arc.h
-	$(CC) $(CFLAGS) -c arc.c
+	$(CC) $(CFLAGS) arc.c
 run: $(BIN)
 	./$(BIN)
 clean:

--- a/arc.c
+++ b/arc.c
@@ -467,6 +467,7 @@ error read_expr(const char *input, const char **end, atom *result)
 		return parse_simple(token, *end, result);
 }
 
+#if !READ_LINE
 char *readline(char *prompt) {
 	size_t size = 80;
 	/* The size is extended by the input with the value of the provisional */
@@ -488,6 +489,7 @@ char *readline(char *prompt) {
 
 	return realloc(str, sizeof(char)*len);
 }
+#endif /* !READ_LINE */
 
 atom env_create(atom parent)
 {
@@ -909,7 +911,7 @@ error builtin_string_sref(atom args, atom *result) {
 	atom index, obj, value;
 	if (len(args) != 3) return ERROR_ARGS;
 	index = car(cdr(cdr(args)));
-	obj = car(args), value;
+	obj = car(args);/*, value; */
 	if (obj.type != T_STRING) return ERROR_TYPE;
 	value = car(cdr(args));
 	obj.value.str->value[(long)index.value.number] = (char)value.value.number;
@@ -1318,7 +1320,7 @@ error arc_load_file(const char *path)
 			atom result;
 			error err = macex_eval(expr, &result);
 			if (err) {
-				print_error(err);				
+				print_error(err);
 				printf("error in expression:\n\t");
 				print_expr(expr);
 				putchar('\n');

--- a/arc.h
+++ b/arc.h
@@ -15,6 +15,15 @@
 #include <math.h>
 #include <time.h>
 
+#ifndef READ_LINE
+#define READ_LINE 1
+#endif
+
+#if READ_LINE
+#include <readline/readline.h>
+#include <readline/history.h>
+#endif
+
 #ifdef _MSC_VER
 #define strdup _strdup
 #endif
@@ -78,7 +87,9 @@ error arc_load_file(const char *path);
 char *get_dir_path(char *file_path);
 void arc_init(char *file_path);
 void print_env();
+#if !READ_LINE
 char *readline(char *prompt);
+#endif
 error read_expr(const char *input, const char **end, atom *result);
 void print_expr(atom atom);
 void print_error(error e);

--- a/arcadia.c
+++ b/arcadia.c
@@ -8,6 +8,11 @@ void repl() {
 	char *input;
 
 	while ((input = readline("> ")) != NULL) {
+#if READ_LINE
+		if (input && *input)
+			add_history(input);
+#endif
+
 		char *buf = (char *)malloc(strlen(input) + 4);
 		sprintf(buf, "(%s\n)", input);
 		const char *p = buf;


### PR DESCRIPTION
Hi,
I've implemented both cursor movement and command history at the REPL with GNU readline. This also required a rewrite of CMakeLists.txt (which had broken at some point in the 26 days since it was last edited anyway) and some small additions to the Makefile.

Compilation with the old custom version of readline instead is still possible with either
'make no-read-line' 
or 
'mkdir build && cd build && cmake -DREAD_LINE=0 .. && make'
but if you feel that, for now at least, it would be better to use this as the default target and have GNU as the specified option, this would be a trivial change to make.
