### PR TITLE
Fix segfault when closure body is empty

### DIFF
--- a/arc.c
+++ b/arc.c
@@ -292,7 +292,7 @@ error make_closure(atom env, atom args, atom body, atom *result)
 {
 	atom p;
 
-	if (!listp(body))
+	if (body.type != T_CONS || !listp(body))
 		return ERROR_SYNTAX;
 
 	/* Check argument names are all symbols or conses */


### PR DESCRIPTION
Examples of segfaults:

	(let x 10)
	(fn ())

It's probably better to fix `listp` itself to check for T_CONS first, but may be slower since in all other places there's this check already.